### PR TITLE
Add ComMarília Stories WordPress plugin

### DIFF
--- a/commarilia-storie-plugin/assets/css/style.css
+++ b/commarilia-storie-plugin/assets/css/style.css
@@ -1,0 +1,135 @@
+/* --- Configurações Globais --- */
+body {
+    font-family: 'Poppins', sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    background-color: #f8f9fa;
+}
+
+/* --- Estilos da Marca --- */
+.logo-text-com { color: #F4A261; }
+.logo-text-marilia { color: #1D3557; }
+
+/* --- Efeitos Visuais --- */
+.text-shadow { text-shadow: 2px 2px 8px rgba(0,0,0,0.7); }
+
+/* --- Lazy Loading Placeholder --- */
+img.lazy {
+    background-color: #e2e8f0;
+}
+
+/* --- Animações e Transições do Menu Lateral --- */
+#side-menu {
+    transform: translateX(-100%);
+    transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+}
+#side-menu.open {
+    transform: translateX(0);
+}
+
+/* --- Animações e Transições do Player de Story --- */
+#story-viewer {
+    transform: scale(0.9);
+    opacity: 0;
+    visibility: hidden;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease, visibility 0s 0.3s;
+}
+#story-viewer.open {
+    transform: scale(1);
+    opacity: 1;
+    visibility: visible;
+    transition-delay: 0s;
+}
+
+/* --- Efeito de Sobreposição no Conteúdo do Story --- */
+#story-container::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 50%);
+    z-index: 1;
+}
+
+/* --- Barras de Progresso do Story --- */
+.progress-bar {
+    flex: 1;
+    height: 3px;
+    background-color: rgba(255, 255, 255, 0.3);
+    border-radius: 2px;
+    overflow: hidden;
+}
+.progress-bar-inner {
+    height: 100%;
+    background-color: white;
+    width: 100%;
+    transform-origin: left;
+    transform: scaleX(0);
+}
+
+/* --- Animações e Transições do Modal --- */
+#story-modal {
+    visibility: hidden;
+    transition: visibility 0s 0.4s;
+}
+#story-modal-overlay {
+    opacity: 0;
+    transition: opacity 0.4s ease;
+}
+#story-modal.open {
+    visibility: visible;
+    transition-delay: 0s;
+}
+#story-modal.open #story-modal-overlay {
+    opacity: 1;
+}
+#story-modal-content {
+    transform: translateY(100%);
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+@media (min-width: 640px) { /* sm breakpoint */
+    #story-modal-content {
+        transform: translateY(-50px) scale(0.95);
+        opacity: 0;
+        transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.4s ease;
+    }
+}
+#story-modal.open #story-modal-content {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+}
+
+/* --- Utilitário para Esconder Barra de Rolagem --- */
+.hide-scrollbar::-webkit-scrollbar { display: none; }
+.hide-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+/* Estilos para o Preview no Gerenciador */
+#story-preview-viewer {
+    aspect-ratio: 9 / 16;
+    width: 100%;
+    max-width: 375px;
+    max-height: 100%;
+    border-radius: 2.5rem;
+    border: 10px solid black;
+    background-color: #000;
+}
+#story-preview-media, #story-preview-video {
+    object-fit: cover;
+}
+#story-preview-container::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(to top, rgba(0,0,0,0.7) 0%, transparent 50%);
+    z-index: 1;
+}
+.story-preview-indicator {
+    width: 8px;
+    height: 8px;
+    background-color: rgba(255, 255, 255, 0.4);
+    border-radius: 50%;
+    transition: all 0.4s ease;
+}
+.story-preview-indicator.active {
+    background-color: white;
+    transform: scale(1.2);
+}

--- a/commarilia-storie-plugin/assets/js/story.js
+++ b/commarilia-storie-plugin/assets/js/story.js
@@ -1,0 +1,215 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const postsData = window.commariliaStories || [];
+    class App {
+        constructor() {
+            this.postsData = postsData;
+            this.ui = new UI();
+            this.storyPlayer = new StoryPlayer(this.ui.getStoryPlayerDOM(), (i) => this.postsData[i]);
+        }
+        init() {
+            this.ui.renderNewsGrid(this.postsData);
+            this.ui.initializeLazyLoading();
+            this.ui.setupEventListeners((idx) => this.storyPlayer.open(idx));
+            if (window.feather) { feather.replace(); }
+        }
+    }
+    class UI {
+        constructor() {
+            this.dom = {
+                newsGrid: document.getElementById('news-grid'),
+                menuBtn: document.getElementById('menu-btn'),
+                closeMenuBtn: document.getElementById('close-menu-btn'),
+                sideMenu: document.getElementById('side-menu'),
+                menuOverlay: document.getElementById('menu-overlay'),
+            };
+        }
+        renderNewsGrid(postsData) {
+            if (!this.dom.newsGrid) return;
+            this.dom.newsGrid.innerHTML = postsData.map((post, index) => `
+                <div class="news-card relative rounded-xl shadow-lg overflow-hidden cursor-pointer h-[480px] group" data-story-index="${index}" role="button" tabindex="0" aria-label="Abrir story: ${post.cardtitle}">
+                    <img data-src="${post.cardimage}" alt="${post.cardtitle}" class="lazy w-full h-full object-cover transform group-hover:scale-105 transition-transform duration-500 ease-in-out">
+                    <div class="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent"></div>
+                    <div class="absolute bottom-0 left-0 p-5 text-white z-10">
+                        <span class="text-white text-xs font-bold px-3 py-1 rounded-full" style="background-color: ${post.categorycolor};">${post.category}</span>
+                        <h2 class="text-xl font-bold mt-2 leading-tight text-shadow">${post.cardtitle}</h2>
+                    </div>
+                </div>
+            `).join('');
+        }
+        initializeLazyLoading() {
+            const lazyImages = document.querySelectorAll('img.lazy');
+            if ("IntersectionObserver" in window) {
+                const observer = new IntersectionObserver((entries) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            const img = entry.target;
+                            img.src = img.dataset.src;
+                            img.classList.remove('lazy');
+                            observer.unobserve(img);
+                        }
+                    });
+                });
+                lazyImages.forEach(img => observer.observe(img));
+            } else { lazyImages.forEach(img => img.src = img.dataset.src); }
+        }
+        setupEventListeners(onCardClick) {
+            this.dom.newsGrid?.addEventListener('click', (e) => {
+                const card = e.target.closest('.news-card');
+                if (card) onCardClick(parseInt(card.dataset.storyIndex));
+            });
+            const toggleMenu = () => {
+                this.dom.sideMenu.classList.toggle('open');
+                this.dom.menuOverlay.classList.toggle('hidden');
+            };
+            this.dom.menuBtn?.addEventListener('click', toggleMenu);
+            this.dom.closeMenuBtn?.addEventListener('click', toggleMenu);
+            this.dom.menuOverlay?.addEventListener('click', toggleMenu);
+        }
+        getStoryPlayerDOM() {
+            return {
+                viewer: document.getElementById('story-viewer'), container: document.getElementById('story-container'),
+                progressContainer: document.getElementById('story-progress-container'), mediaContainer: document.getElementById('story-media-container'),
+                title: document.getElementById('story-title-viewer'), time: document.getElementById('story-time'),
+                closeBtn: document.getElementById('close-story-btn'), shareBtn: document.getElementById('share-story-btn'),
+                nextArea: document.getElementById('next-story-area'), prevArea: document.getElementById('prev-story-area'),
+                swipeUp: document.getElementById('full-story-swipe-up'), modal: document.getElementById('story-modal'),
+                modalOverlay: document.getElementById('story-modal-overlay'), closeModalBtn: document.getElementById('close-modal-btn'),
+                modalImage: document.getElementById('modal-image'), modalTitle: document.getElementById('modal-title'), modalText: document.getElementById('modal-text'),
+            };
+        }
+        displayError(message) {
+            if (this.dom.newsGrid) {
+                this.dom.newsGrid.innerHTML = `<p class="col-span-full text-center text-red-500">${message}</p>`;
+            }
+        }
+    }
+    class StoryPlayer {
+        constructor(dom, getStoryDataCallback) {
+            this.dom = dom; this.getStoryData = getStoryDataCallback;
+            this.state = { currentStoryIndex: 0, currentPageIndex: 0, isPaused: false };
+            this.progressTimer = null; this.init();
+        }
+        init() {
+            this.dom.closeBtn?.addEventListener('click', () => this.close());
+            this.dom.nextArea?.addEventListener('click', () => this.nextPage());
+            this.dom.prevArea?.addEventListener('click', () => this.prevPage());
+            this.dom.swipeUp?.addEventListener('click', () => this.openModal());
+            this.dom.shareBtn?.addEventListener('click', () => this.shareStory());
+            const pauseStory = () => { this.state.isPaused = true; };
+            const resumeStory = () => { this.state.isPaused = false; };
+            this.dom.container.addEventListener('mousedown', pauseStory);
+            this.dom.container.addEventListener('touchstart', pauseStory, { passive: true });
+            this.dom.container.addEventListener('mouseup', resumeStory);
+            this.dom.container.addEventListener('touchend', resumeStory);
+            document.addEventListener('keydown', (e) => {
+                if (this.dom.viewer.classList.contains('open')) {
+                    if (e.key === 'ArrowRight') this.nextPage();
+                    if (e.key === 'ArrowLeft') this.prevPage();
+                    if (e.key === 'Escape') this.close();
+                }
+            });
+            this.dom.closeModalBtn?.addEventListener('click', () => this.closeModal());
+            this.dom.modalOverlay?.addEventListener('click', () => this.closeModal());
+        }
+        open(storyIndex) {
+            this.state.currentStoryIndex = storyIndex; this.state.currentPageIndex = 0; this.state.isPaused = false;
+            this.updatePage(true); this.dom.viewer?.classList.add('open'); document.body.style.overflow = 'hidden';
+        }
+        close() {
+            this.dom.viewer?.classList.remove('open'); document.body.style.overflow = '';
+            this.dom.mediaContainer.innerHTML = ''; cancelAnimationFrame(this.progressTimer);
+        }
+        updatePage(isFirstPage = false) {
+            const story = this.getStoryData(this.state.currentStoryIndex);
+            const page = story?.pages?.[this.state.currentPageIndex];
+            if (!page) { this.close(); return; }
+            if (isFirstPage) this.buildProgressBars();
+            this.updateProgressBars();
+            this.dom.mediaContainer.innerHTML = '';
+            const mediaElement = page.media_type === 'video' ? document.createElement('video') : document.createElement('img');
+            mediaElement.src = page.media_url;
+            mediaElement.className = 'w-full h-full object-cover';
+            if (page.media_type === 'video') {
+                mediaElement.autoplay = true; mediaElement.muted = true; mediaElement.loop = true; mediaElement.playsInline = true;
+            }
+            this.dom.mediaContainer.appendChild(mediaElement);
+            this.dom.title.innerHTML = page.text;
+            this.dom.time.textContent = this.formatTimeAgo(story.timestamp);
+            this.dom.swipeUp.style.display = page.show_link ? 'block' : 'none';
+            this.startProgressBar();
+        }
+        nextPage() {
+            const story = this.getStoryData(this.state.currentStoryIndex);
+            if (this.state.currentPageIndex < story.pages.length - 1) {
+                this.state.currentPageIndex++; this.updatePage();
+            } else { this.close(); }
+        }
+        prevPage() {
+            if (this.state.currentPageIndex > 0) { this.state.currentPageIndex--; this.updatePage(); }
+        }
+        buildProgressBars() {
+            this.dom.progressContainer.innerHTML = '';
+            const story = this.getStoryData(this.state.currentStoryIndex);
+            story.pages.forEach(() => {
+                const bar = document.createElement('div');
+                bar.className = 'progress-bar';
+                bar.innerHTML = '<div class="progress-bar-inner"></div>';
+                this.dom.progressContainer.appendChild(bar);
+            });
+        }
+        updateProgressBars() {
+            const bars = this.dom.progressContainer.querySelectorAll('.progress-bar-inner');
+            bars.forEach((bar, index) => {
+                bar.style.transform = 'scaleX(0)';
+                if (index < this.state.currentPageIndex) { bar.style.transform = 'scaleX(1)'; }
+            });
+        }
+        startProgressBar() {
+            cancelAnimationFrame(this.progressTimer);
+            const DURATION = 5000; let startTime = null;
+            const bar = this.dom.progressContainer.querySelectorAll('.progress-bar-inner')[this.state.currentPageIndex];
+            if (!bar) return;
+            const animate = (timestamp) => {
+                if (!startTime) startTime = timestamp;
+                if (!this.state.isPaused) {
+                    const elapsed = timestamp - startTime;
+                    const progress = Math.min(elapsed / DURATION, 1);
+                    bar.style.transform = `scaleX(${progress})`;
+                    if (progress >= 1) { this.nextPage(); return; }
+                } else {
+                    const currentProgress = parseFloat(bar.style.transform.replace('scaleX(', ''));
+                    startTime = timestamp - (currentProgress * DURATION);
+                }
+                this.progressTimer = requestAnimationFrame(animate);
+            };
+            this.progressTimer = requestAnimationFrame(animate);
+        }
+        async shareStory() {
+            const story = this.getStoryData(this.state.currentStoryIndex);
+            try {
+                await navigator.share({ title: story.cardtitle, text: `Confira: ${story.cardtitle}`, url: window.location.href });
+            } catch (err) { console.error('Erro ao compartilhar:', err); }
+        }
+        openModal() {
+            const story = this.getStoryData(this.state.currentStoryIndex);
+            if (!story.fullcontent) return;
+            this.state.isPaused = true;
+            this.dom.modalImage.src = story.fullcontent.image || story.cardimage;
+            this.dom.modalTitle.textContent = story.fullcontent.title || story.cardtitle;
+            this.dom.modalText.innerHTML = story.fullcontent.body || '';
+            this.dom.modal.classList.add('open');
+        }
+        closeModal() { this.dom.modal.classList.remove('open'); this.state.isPaused = false; }
+        formatTimeAgo(isoString) {
+            const seconds = Math.floor((new Date() - new Date(isoString)) / 1000);
+            let interval = seconds / 31536000; if (interval > 1) return Math.floor(interval) + 'a';
+            interval = seconds / 2592000; if (interval > 1) return Math.floor(interval) + 'm';
+            interval = seconds / 86400; if (interval > 1) return Math.floor(interval) + 'd';
+            interval = seconds / 3600; if (interval > 1) return Math.floor(interval) + 'h';
+            interval = seconds / 60; if (interval > 1) return Math.floor(interval) + 'min';
+            return 'agora';
+        }
+    }
+    const app = new App();
+    app.init();
+});

--- a/commarilia-storie-plugin/commarilia-storie.php
+++ b/commarilia-storie-plugin/commarilia-storie.php
@@ -1,0 +1,259 @@
+<?php
+/*
+Plugin Name: ComMarília Stories
+Description: Sistema de stories e notícias com player no estilo Web Story.
+Version: 1.0.0
+Author: OpenAI Assistant
+*/
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ComMariliaStories {
+    public function __construct() {
+        add_action( 'init', [ $this, 'register_post_type' ] );
+        add_action( 'add_meta_boxes', [ $this, 'register_meta_boxes' ] );
+        add_action( 'save_post_commarilia_story', [ $this, 'save_meta' ] );
+        add_shortcode( 'commarilia_stories', [ $this, 'render_shortcode' ] );
+        add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+    }
+
+    public static function activate() {
+        $self = new self();
+        $self->register_post_type();
+        flush_rewrite_rules();
+        if ( ! get_posts( [ 'post_type' => 'commarilia_story', 'numberposts' => 1 ] ) ) {
+            $self->insert_demo_content();
+        }
+    }
+
+    public function register_post_type() {
+        $labels = [
+            'name' => 'Stories',
+            'singular_name' => 'Story',
+        ];
+        $args = [
+            'labels' => $labels,
+            'public' => true,
+            'show_in_rest' => true,
+            'supports' => [ 'title' ],
+            'has_archive' => false,
+            'rewrite' => [ 'slug' => 'stories' ],
+        ];
+        register_post_type( 'commarilia_story', $args );
+    }
+
+    public function register_meta_boxes() {
+        add_meta_box( 'commarilia_story_meta', 'Detalhes do Story', [ $this, 'meta_box_html' ], 'commarilia_story', 'normal', 'high' );
+    }
+
+    public function meta_box_html( $post ) {
+        wp_nonce_field( 'commarilia_story_save', 'commarilia_story_nonce' );
+        $category       = get_post_meta( $post->ID, '_cm_category', true );
+        $category_color = get_post_meta( $post->ID, '_cm_category_color', true );
+        $card_image     = get_post_meta( $post->ID, '_cm_card_image', true );
+        $pages          = get_post_meta( $post->ID, '_cm_story_pages', true );
+        $full           = get_post_meta( $post->ID, '_cm_fullcontent', true );
+        $timestamp      = get_post_meta( $post->ID, '_cm_timestamp', true );
+        if ( empty( $pages ) ) {
+            $pages = [];
+        }
+        ?>
+        <p>
+            <label for="cm_category"><strong>Categoria</strong></label><br />
+            <input type="text" name="cm_category" id="cm_category" value="<?php echo esc_attr( $category ); ?>" class="widefat" />
+        </p>
+        <p>
+            <label for="cm_category_color"><strong>Cor da Categoria</strong></label><br />
+            <input type="text" name="cm_category_color" id="cm_category_color" value="<?php echo esc_attr( $category_color ); ?>" class="widefat" placeholder="#2563eb" />
+        </p>
+        <p>
+            <label for="cm_card_image"><strong>URL da Imagem do Card</strong></label><br />
+            <input type="text" name="cm_card_image" id="cm_card_image" value="<?php echo esc_url( $card_image ); ?>" class="widefat" />
+        </p>
+        <p>
+            <label for="cm_card_title"><strong>Título do Card</strong></label><br />
+            <input type="text" name="cm_card_title" id="cm_card_title" value="<?php echo esc_attr( get_post_meta( $post->ID, '_cm_card_title', true ) ); ?>" class="widefat" />
+        </p>
+        <p>
+            <label><strong>Páginas do Story</strong></label>
+            <div id="cm-pages">
+                <?php foreach ( $pages as $index => $page ) : ?>
+                    <div class="cm-page" style="margin-bottom:10px;border:1px solid #ddd;padding:10px;">
+                        <label>URL da Mídia<br /><input type="text" name="cm_pages[<?php echo $index; ?>][media_url]" value="<?php echo esc_url( $page['media_url'] ?? '' ); ?>" class="widefat" /></label>
+                        <label>Texto<br /><textarea name="cm_pages[<?php echo $index; ?>][text]" class="widefat"><?php echo esc_textarea( $page['text'] ?? '' ); ?></textarea></label>
+                        <label><input type="checkbox" name="cm_pages[<?php echo $index; ?>][show_link]" <?php checked( ! empty( $page['show_link'] ) ); ?> /> Mostrar link para Matéria</label>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+            <button type="button" class="button" id="cm-add-page">Adicionar página</button>
+        </p>
+        <p>
+            <label for="cm_full_title"><strong>Título da Matéria Completa</strong></label><br />
+            <input type="text" name="cm_full[title]" id="cm_full_title" value="<?php echo esc_attr( $full['title'] ?? '' ); ?>" class="widefat" />
+        </p>
+        <p>
+            <label for="cm_full_image"><strong>Imagem da Matéria Completa</strong></label><br />
+            <input type="text" name="cm_full[image]" id="cm_full_image" value="<?php echo esc_url( $full['image'] ?? '' ); ?>" class="widefat" />
+        </p>
+        <p>
+            <label for="cm_full_body"><strong>Conteúdo da Matéria</strong></label><br />
+            <textarea name="cm_full[body]" id="cm_full_body" class="widefat" rows="6"><?php echo esc_textarea( $full['body'] ?? '' ); ?></textarea>
+        </p>
+        <p>
+            <label for="cm_timestamp"><strong>Data de Publicação</strong></label><br />
+            <input type="datetime-local" name="cm_timestamp" id="cm_timestamp" value="<?php echo esc_attr( $timestamp ? date( 'Y-m-d\TH:i', strtotime( $timestamp ) ) : '' ); ?>" />
+        </p>
+        <script>
+        document.getElementById('cm-add-page')?.addEventListener('click', function(){
+            const container = document.getElementById('cm-pages');
+            const index = container.children.length;
+            const div = document.createElement('div');
+            div.className = 'cm-page';
+            div.style.marginBottom = '10px';
+            div.style.border = '1px solid #ddd';
+            div.style.padding = '10px';
+            div.innerHTML = '<label>URL da Mídia<br /><input type="text" name="cm_pages['+index+'][media_url]" class="widefat" /></label>'+
+                            '<label>Texto<br /><textarea name="cm_pages['+index+'][text]" class="widefat"></textarea></label>'+
+                            '<label><input type="checkbox" name="cm_pages['+index+'][show_link]" /> Mostrar link para Matéria</label>';
+            container.appendChild(div);
+        });
+        </script>
+        <?php
+    }
+
+    public function save_meta( $post_id ) {
+        if ( ! isset( $_POST['commarilia_story_nonce'] ) || ! wp_verify_nonce( $_POST['commarilia_story_nonce'], 'commarilia_story_save' ) ) {
+            return;
+        }
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        update_post_meta( $post_id, '_cm_category', sanitize_text_field( $_POST['cm_category'] ?? '' ) );
+        update_post_meta( $post_id, '_cm_category_color', sanitize_text_field( $_POST['cm_category_color'] ?? '' ) );
+        update_post_meta( $post_id, '_cm_card_image', esc_url_raw( $_POST['cm_card_image'] ?? '' ) );
+        update_post_meta( $post_id, '_cm_card_title', sanitize_text_field( $_POST['cm_card_title'] ?? '' ) );
+        $pages = [];
+        if ( isset( $_POST['cm_pages'] ) && is_array( $_POST['cm_pages'] ) ) {
+            foreach ( $_POST['cm_pages'] as $page ) {
+                if ( empty( $page['media_url'] ) ) {
+                    continue;
+                }
+                $pages[] = [
+                    'media_url' => esc_url_raw( $page['media_url'] ),
+                    'media_type' => strtolower( pathinfo( $page['media_url'], PATHINFO_EXTENSION ) ) === 'mp4' ? 'video' : 'image',
+                    'text' => sanitize_text_field( $page['text'] ?? '' ),
+                    'show_link' => ! empty( $page['show_link'] ),
+                ];
+            }
+        }
+        update_post_meta( $post_id, '_cm_story_pages', $pages );
+        $full = $_POST['cm_full'] ?? [];
+        $full_sanitized = [
+            'title' => sanitize_text_field( $full['title'] ?? '' ),
+            'image' => esc_url_raw( $full['image'] ?? '' ),
+            'body'  => wp_kses_post( $full['body'] ?? '' ),
+        ];
+        update_post_meta( $post_id, '_cm_fullcontent', $full_sanitized );
+        $timestamp = $_POST['cm_timestamp'] ?? '';
+        if ( $timestamp ) {
+            update_post_meta( $post_id, '_cm_timestamp', gmdate( 'c', strtotime( $timestamp ) ) );
+        }
+    }
+
+    public function enqueue_assets() {
+        if ( ! is_singular() ) {
+            return;
+        }
+        $post = get_post();
+        if ( ! $post || ! has_shortcode( $post->post_content, 'commarilia_stories' ) ) {
+            return;
+        }
+        wp_enqueue_script( 'tailwindcss', 'https://cdn.tailwindcss.com', [], null, false );
+        wp_enqueue_script( 'feather-icons', 'https://unpkg.com/feather-icons', [], null, true );
+        wp_enqueue_style( 'commarilia-storie-style', plugin_dir_url( __FILE__ ) . 'assets/css/style.css', [], '1.0.0' );
+        wp_enqueue_script( 'commarilia-storie-script', plugin_dir_url( __FILE__ ) . 'assets/js/story.js', [ 'feather-icons' ], '1.0.0', true );
+        wp_localize_script( 'commarilia-storie-script', 'commariliaStories', $this->get_stories_data() );
+    }
+
+    public function get_stories_data() {
+        $posts = get_posts( [ 'post_type' => 'commarilia_story', 'post_status' => 'publish', 'numberposts' => -1, 'orderby' => 'date', 'order' => 'DESC' ] );
+        $data = [];
+        foreach ( $posts as $post ) {
+            $data[] = [
+                'id' => $post->ID,
+                'category' => get_post_meta( $post->ID, '_cm_category', true ),
+                'categorycolor' => get_post_meta( $post->ID, '_cm_category_color', true ),
+                'cardtitle' => get_post_meta( $post->ID, '_cm_card_title', true ) ?: $post->post_title,
+                'cardimage' => get_post_meta( $post->ID, '_cm_card_image', true ),
+                'timestamp' => get_post_meta( $post->ID, '_cm_timestamp', true ),
+                'pages' => get_post_meta( $post->ID, '_cm_story_pages', true ),
+                'fullcontent' => get_post_meta( $post->ID, '_cm_fullcontent', true ),
+            ];
+        }
+        return $data;
+    }
+
+    public function render_shortcode() {
+        ob_start();
+        include plugin_dir_path( __FILE__ ) . 'templates/stories-grid.php';
+        return ob_get_clean();
+    }
+
+    private function insert_demo_content() {
+        $demo_posts = [
+            [
+                'category' => 'TECNOLOGIA',
+                'categorycolor' => '#2563eb',
+                'cardtitle' => 'Lançamento de novo smartphone',
+                'cardimage' => 'https://picsum.photos/seed/tech/800/600',
+                'pages' => [
+                    [ 'media_url' => 'https://picsum.photos/seed/tech1/800/600', 'media_type' => 'image', 'text' => 'Novidades do aparelho', 'show_link' => true ],
+                    [ 'media_url' => 'https://picsum.photos/seed/tech2/800/600', 'media_type' => 'image', 'text' => 'Design impressionante', 'show_link' => true ],
+                ],
+                'fullcontent' => [
+                    'title' => 'Lançamento de novo smartphone',
+                    'image' => 'https://picsum.photos/seed/tech/800/600',
+                    'body'  => '<p>Detalhes completos da notícia sobre o lançamento do novo smartphone.</p>',
+                ],
+            ],
+            [
+                'category' => 'ESPORTE',
+                'categorycolor' => '#e11d48',
+                'cardtitle' => 'Equipe vence campeonato',
+                'cardimage' => 'https://picsum.photos/seed/sports/800/600',
+                'pages' => [
+                    [ 'media_url' => 'https://picsum.photos/seed/sports1/800/600', 'media_type' => 'image', 'text' => 'Celebrando a vitória', 'show_link' => true ],
+                    [ 'media_url' => 'https://picsum.photos/seed/sports2/800/600', 'media_type' => 'image', 'text' => 'Melhores momentos', 'show_link' => true ],
+                ],
+                'fullcontent' => [
+                    'title' => 'Equipe vence campeonato',
+                    'image' => 'https://picsum.photos/seed/sports/800/600',
+                    'body'  => '<p>Resumo do jogo e detalhes da vitória da equipe.</p>',
+                ],
+            ],
+        ];
+        foreach ( $demo_posts as $demo ) {
+            $post_id = wp_insert_post( [
+                'post_type' => 'commarilia_story',
+                'post_status' => 'publish',
+                'post_title' => $demo['cardtitle'],
+            ] );
+            if ( $post_id ) {
+                update_post_meta( $post_id, '_cm_category', $demo['category'] );
+                update_post_meta( $post_id, '_cm_category_color', $demo['categorycolor'] );
+                update_post_meta( $post_id, '_cm_card_image', $demo['cardimage'] );
+                update_post_meta( $post_id, '_cm_card_title', $demo['cardtitle'] );
+                update_post_meta( $post_id, '_cm_story_pages', $demo['pages'] );
+                update_post_meta( $post_id, '_cm_fullcontent', $demo['fullcontent'] );
+                update_post_meta( $post_id, '_cm_timestamp', current_time( 'c' ) );
+            }
+        }
+    }
+}
+
+register_activation_hook( __FILE__, [ 'ComMariliaStories', 'activate' ] );
+new ComMariliaStories();
+
+?>

--- a/commarilia-storie-plugin/templates/stories-grid.php
+++ b/commarilia-storie-plugin/templates/stories-grid.php
@@ -1,0 +1,92 @@
+<!-- Menu Lateral -->
+<aside id="side-menu" class="fixed top-0 left-0 h-full w-72 bg-white shadow-2xl z-[70]">
+    <div class="p-6 flex justify-between items-center border-b">
+        <div class="text-xl font-black">
+            <span class="logo-text-com">Com</span><span class="logo-text-marilia">Marília.</span>
+        </div>
+        <button id="close-menu-btn" class="text-gray-500 hover:text-gray-800" aria-label="Fechar menu">
+            <i data-feather="x" class="w-6 h-6"></i>
+        </button>
+    </div>
+    <nav class="p-6">
+        <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">Categorias</h2>
+        <a href="#" class="flex items-center gap-4 py-3 px-4 text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"><i data-feather="home" class="w-5 h-5"></i><span>Início</span></a>
+        <a href="#" class="flex items-center gap-4 py-3 px-4 text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"><i data-feather="globe" class="w-5 h-5"></i><span>Mundo</span></a>
+        <a href="#" class="flex items-center gap-4 py-3 px-4 text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"><i data-feather="trending-up" class="w-5 h-5"></i><span>Economia</span></a>
+        <a href="#" class="flex items-center gap-4 py-3 px-4 text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"><i data-feather="award" class="w-5 h-5"></i><span>Esportes</span></a>
+        <a href="#" class="flex items-center gap-4 py-3 px-4 text-gray-700 hover:bg-gray-100 rounded-lg transition-colors"><i data-feather="at-sign" class="w-5 h-5"></i><span>Contato</span></a>
+    </nav>
+</aside>
+<div id="menu-overlay" class="fixed inset-0 bg-black bg-opacity-60 z-[60] hidden backdrop-blur-sm"></div>
+
+<!-- Cabeçalho Principal -->
+<header class="bg-white/80 backdrop-blur-lg shadow-sm sticky top-0 z-40">
+    <div class="container mx-auto px-4 py-4 flex justify-between items-center max-w-5xl">
+        <button id="menu-btn" class="text-gray-600 hover:text-gray-900 focus:outline-none" aria-label="Abrir menu">
+            <i data-feather="menu" class="w-6 h-6"></i>
+        </button>
+        <div class="text-2xl font-black">
+            <span class="logo-text-com">Com</span><span class="logo-text-marilia">Marília.</span>
+        </div>
+        <button class="text-gray-600 hover:text-gray-900 focus:outline-none" aria-label="Perfil do usuário">
+            <i data-feather="user" class="w-6 h-6"></i>
+        </button>
+    </div>
+</header>
+
+<!-- Conteúdo Principal -->
+<main class="container mx-auto px-4 py-8 max-w-5xl">
+    <h1 class="text-3xl font-bold mb-6 text-gray-900">Últimas Notícias</h1>
+    <div id="news-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
+</main>
+
+<!-- Player de Web Story -->
+<div id="story-viewer" class="fixed inset-0 bg-black z-50 flex flex-col items-center justify-center" role="dialog" aria-modal="true" aria-labelledby="story-title-viewer">
+    <div id="story-container" class="relative w-full h-full sm:max-w-[414px] sm:h-[90vh] sm:max-h-[896px] bg-gray-900 sm:rounded-xl overflow-hidden shadow-2xl">
+        <div id="story-progress-container" class="absolute top-2 left-0 w-full flex gap-1 px-2 z-20"></div>
+        <div id="story-media-container" class="w-full h-full absolute inset-0"></div>
+        <header class="absolute top-8 left-0 w-full p-4 flex items-center gap-3 z-20">
+            <img id="story-publisher-logo" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZHRoPSI0MCIgdmlld0JveD0iMCAwIDEwMCAxMDAiPjxyZWN0IHdpZHRoPSIxMDAiIGhlaWdodD0iMTAwIiByeD0iNTAiIGZpbGw9IiNGRkZGRkYiLz48dGV4dCB4PSI1MCIgeT0iNjgiIGZvbnQtZmFtaWx5PSJQb3BwaW5zLCBzYW5zLXNlcmlmIiBmb250LXNpemU9IjQwIiBmb250LXdlaWdodD0iOTAwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj48dHNwYW4gZmlsbD0iI0Y0QTkyMSI+QzwvdHNwYW4+PHRzcGFuIGZpbGw9IiMxRDM1NTciPk08L3RzcGFuPjwvdGV4dD48L3N2Zz4=" class="w-10 h-10 rounded-full border-2 border-white/50" alt="Logo do ComMarília">
+            <div>
+                <div id="story-publisher-name" class="font-bold text-white text-sm">ComMarília</div>
+                <div id="story-time" class="text-white/80 text-xs"></div>
+            </div>
+        </header>
+        <div class="absolute bottom-24 left-0 p-6 text-white z-10 w-full">
+            <div id="story-title-viewer" class="text-2xl font-bold leading-tight text-shadow"></div>
+        </div>
+        <div id="prev-story-area" class="absolute left-0 top-0 h-full w-1/3 cursor-pointer z-30" aria-label="Página anterior do story"></div>
+        <div id="next-story-area" class="absolute right-0 top-0 h-full w-2/3 cursor-pointer z-30" aria-label="Próxima página do story"></div>
+        <div class="absolute top-8 right-4 flex items-center gap-2 z-30">
+            <button id="share-story-btn" class="text-white bg-black/30 rounded-full p-2" aria-label="Compartilhar story">
+                <i data-feather="share-2" class="w-6 h-6"></i>
+            </button>
+            <button id="close-story-btn" class="text-white bg-black/30 rounded-full p-2" aria-label="Fechar story">
+                <i data-feather="x" class="w-6 h-6"></i>
+            </button>
+        </div>
+        <div id="full-story-swipe-up" class="absolute bottom-10 left-0 w-full z-30 p-6 text-center cursor-pointer">
+            <div class="inline-flex flex-col items-center gap-1 text-white animate-bounce">
+                <i data-feather="chevron-up" class="w-6 h-6"></i>
+                <span class="font-semibold text-sm">Matéria Completa</span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Modal da Matéria Completa -->
+<div id="story-modal" class="fixed inset-0 z-[80] flex items-end sm:items-start sm:pt-12 justify-center" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div id="story-modal-overlay" class="absolute inset-0 bg-black bg-opacity-50"></div>
+    <div id="story-modal-content" class="relative bg-white rounded-t-2xl sm:rounded-2xl shadow-xl max-w-2xl w-full max-h-[90vh] sm:max-h-[calc(100vh-4rem)] overflow-y-auto hide-scrollbar">
+        <header class="sticky top-0 flex justify-between items-center p-4 border-b bg-white z-10">
+            <h2 id="modal-title" class="text-xl font-bold"></h2>
+            <button id="close-modal-btn" class="text-gray-500 hover:text-gray-800" aria-label="Fechar matéria completa">
+                <i data-feather="x" class="w-6 h-6"></i>
+            </button>
+        </header>
+        <div class="p-4 space-y-4">
+            <img id="modal-image" src="" alt="" class="w-full h-48 object-cover rounded-lg">
+            <div id="modal-text" class="prose max-w-none"></div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add `ComMarília Stories` plugin registering a custom post type and meta boxes for story content
- include front-end story player with Tailwind/Feather assets and shortcode output
- seed demo stories on activation for populated home

## Testing
- `php -l commarilia-storie-plugin/commarilia-storie.php`
- `node --check commarilia-storie-plugin/assets/js/story.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fef6c47083269162fa8d5a80c84b